### PR TITLE
feat: Disable macOS startup sound

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -103,5 +103,11 @@
       location = "~/Desktop/screenshot";
       type = "png";
     };
+
+    CustomUserPreferences = {
+      "com.apple.Sound" = {
+        "Play sound on startup" = false;
+      };
+    };
   };
 }


### PR DESCRIPTION
## Summary
- Add system configuration to disable the startup sound on macOS
- Uses nix-darwin's `CustomUserPreferences` with `com.apple.Sound` setting
- Compatible with macOS Big Sur 11+ systems

## Test plan
- [ ] Run `make switch` to apply the configuration
- [ ] Restart the system to verify startup sound is disabled
- [ ] Confirm the setting persists across reboots

🤖 Generated with [Claude Code](https://claude.ai/code)