### PR TITLE
Downgrade Claude Code to version 1.0.24

### DIFF
--- a/home-manager/programs/claude/default.nix
+++ b/home-manager/programs/claude/default.nix
@@ -1,6 +1,19 @@
 { pkgs, lib, ... }:
 
 {
+  # Overlay to downgrade Claude Code to version 1.0.24
+  nixpkgs.overlays = [
+    (self: super: {
+      claude-code = super.claude-code.overrideAttrs (oldAttrs: rec {
+        version = "1.0.24";
+        src = pkgs.fetchurl {
+          url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
+          sha256 = "1ci3l4l3xjr9xalmldi42d6zkwjc5p1nw04ccxlvnczj1syfnwsm";
+        };
+      });
+    })
+  ];
+
   nixpkgs.config.allowUnfreePredicate =
     pkg:
     builtins.elem (lib.getName pkg) [


### PR DESCRIPTION
## Overview
Downgrades Claude Code to version 1.0.24 for stability and compatibility.

## Changes
- Add nixpkgs overlay to pin Claude Code to specific version 1.0.24
- Use SHA256 hash retrieved from npm registry for package integrity
- Maintain existing unfree package allowlist configuration

## Rationale
Ensures stable operation with a known working version of Claude Code.

## Testing
- ✅ Syntax validation with `nix flake check`
- ✅ Build verification with `nix build --dry-run`
- ✅ Package derivation includes claude-code-1.0.24

## Technical Details
- **Version**: 1.0.24 (downgrade from current latest)
- **Source**: https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.24.tgz
- **SHA256**: 1ci3l4l3xjr9xalmldi42d6zkwjc5p1nw04ccxlvnczj1syfnwsm
